### PR TITLE
Remove lexeme from token

### DIFF
--- a/src/ast/token.rs
+++ b/src/ast/token.rs
@@ -1,30 +1,68 @@
-use std::{fmt::Display, sync::Arc};
+use std::sync::Arc;
 
 use miette::{NamedSource, SourceSpan};
+use strum::Display;
 
 #[derive(Debug, Clone, PartialEq)]
+pub struct Token {
+    pub token_type: TokenType,
+    pub location: SourceSpan,
+    pub src: Arc<NamedSource<String>>,
+}
+
+impl Token {
+    pub fn new(token_type: TokenType, location: SourceSpan, src: Arc<NamedSource<String>>) -> Self {
+        Self {
+            token_type,
+            location,
+            src,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Display)]
+#[strum(serialize_all = "lowercase")]
 pub enum TokenType {
     //single character tokens.
+    #[strum(serialize = "(")]
     LeftParen,
+    #[strum(serialize = ")")]
     RightParen,
+    #[strum(serialize = "{")]
     LeftBrace,
+    #[strum(serialize = "}")]
     RightBrace,
+    #[strum(serialize = ",")]
     Comma,
+    #[strum(serialize = ".")]
     Dot,
+    #[strum(serialize = "-")]
     Minus,
+    #[strum(serialize = "+")]
     Plus,
+    #[strum(serialize = ";")]
     Semicolon,
+    #[strum(serialize = "/")]
     Slash,
+    #[strum(serialize = "*")]
     Star,
 
     // One or two character tokens.
+    #[strum(serialize = "!")]
     Bang,
+    #[strum(serialize = "!=")]
     BangEqual,
+    #[strum(serialize = "=")]
     Equal,
+    #[strum(serialize = "==")]
     EqualEqual,
+    #[strum(serialize = ">")]
     Greater,
+    #[strum(serialize = ">=")]
     GreaterEqual,
+    #[strum(serialize = "<")]
     Less,
+    #[strum(serialize = "<=")]
     LessEqual,
 
     // Literals
@@ -52,34 +90,4 @@ pub enum TokenType {
 
     // Eof
     Eof,
-}
-
-impl Display for TokenType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self) // Display in terms of debug. Antipattern?
-    }
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub struct Token {
-    pub token_type: TokenType,
-    pub lexeme: String,
-    pub location: SourceSpan,
-    pub src: Arc<NamedSource<String>>,
-}
-
-impl Token {
-    pub fn new<S: Into<String>>(
-        token_type: TokenType,
-        lexeme: S,
-        location: SourceSpan,
-        src: Arc<NamedSource<String>>,
-    ) -> Self {
-        Self {
-            token_type,
-            lexeme: lexeme.into(),
-            location,
-            src,
-        }
-    }
 }

--- a/src/interpreter/expression.rs
+++ b/src/interpreter/expression.rs
@@ -97,7 +97,7 @@ impl Interpreter {
         match (left_value?, right_value?) {
             (Value::Number(l), Value::Number(r)) => Ok(f(l, r)),
             (Value::Number(_), value) => Err(WrongType {
-                operator: token.lexeme.clone(),
+                operator: token.token_type.to_string(),
                 expected: Type::Number,
                 actual: value.get_type(),
                 src: token.src.clone(),
@@ -105,7 +105,7 @@ impl Interpreter {
                 operand_location: right.location,
             }),
             (value, Value::Number(_)) => Err(WrongType {
-                operator: token.lexeme.clone(),
+                operator: token.token_type.to_string(),
                 expected: Type::Number,
                 actual: value.get_type(),
                 src: token.src.clone(),
@@ -113,7 +113,7 @@ impl Interpreter {
                 operand_location: left.location,
             }),
             (lhs, rhs) => Err(WrongTypes {
-                operator: token.lexeme.clone(),
+                operator: token.token_type.to_string(),
                 expected: Type::Number,
                 actual_lhs: lhs.get_type(),
                 actual_rhs: rhs.get_type(),
@@ -195,7 +195,7 @@ impl Interpreter {
                     Ok(Value::Number(-num))
                 } else {
                     Err(WrongType {
-                        operator: token.lexeme.clone(),
+                        operator: token.token_type.to_string(),
                         expected: Type::Number,
                         actual: right.get_type(),
                         src: token.src.clone(),
@@ -406,7 +406,6 @@ mod value_interpreter_tests {
     fn token(token_type: TokenType) -> Token {
         Token::new(
             token_type,
-            "",
             (0, 1).into(),
             NamedSource::new("name", String::new()).into(),
         )

--- a/src/interpreter/runtime_error.rs
+++ b/src/interpreter/runtime_error.rs
@@ -8,7 +8,9 @@ use super::value::Value;
 
 #[derive(thiserror::Error, Debug, Diagnostic)]
 pub enum RuntimeError {
-    #[error("Wrong operand type for operator {operator} : expected {expected} but got {actual}")]
+    #[error(
+        "Wrong operand type for operator \"{operator}\": expected {expected} but got {actual}"
+    )]
     #[diagnostic(help("Change operand to {expected}"))]
     WrongType {
         operator: String,
@@ -21,7 +23,7 @@ pub enum RuntimeError {
         #[label("{actual}")]
         operand_location: SourceSpan,
     },
-    #[error("Wrong operand types for operator {operator} : expected {expected} but got {actual_lhs} and {actual_rhs}")]
+    #[error("Wrong operand types for operator \"{operator}\": expected {expected} but got {actual_lhs} and {actual_rhs}")]
     #[diagnostic(help("Change operands to {expected}"))]
     WrongTypes {
         operator: String,
@@ -37,7 +39,7 @@ pub enum RuntimeError {
         #[label("{actual_rhs}")]
         rhs: SourceSpan,
     },
-    #[error("Wrong operand types for operator + : expected both String of both Number but got {actual_lhs} and {actual_rhs}")]
+    #[error("Wrong operand types for operator \"+\": expected both String of both Number but got {actual_lhs} and {actual_rhs}")]
     #[diagnostic(help("Change operands to be both String or Number"))]
     PlusOperatorWrongTypes {
         actual_lhs: Type,

--- a/src/interpreter/statement.rs
+++ b/src/interpreter/statement.rs
@@ -105,6 +105,8 @@ impl Interpreter {
 #[cfg(test)]
 mod stmt_interpreter_tests {
 
+    use std::sync::Arc;
+
     use miette::NamedSource;
 
     use crate::{
@@ -170,9 +172,8 @@ mod stmt_interpreter_tests {
     fn token(token_type: TokenType) -> Token {
         Token::new(
             token_type,
-            "",
             (0, 1).into(),
-            NamedSource::new("name", String::new()).into(),
+            Arc::new(NamedSource::new("name", String::new())),
         )
     }
 
@@ -180,7 +181,7 @@ mod stmt_interpreter_tests {
         Stmt {
             stmt_type: StmtType::Block(stmts),
             location: (0, 1).into(),
-            src: NamedSource::new("name", String::new()).into(),
+            src: Arc::new(NamedSource::new("name", String::new())),
         }
     }
 
@@ -195,7 +196,7 @@ mod stmt_interpreter_tests {
                 initializer: None,
             },
             location: (0, 1).into(),
-            src: NamedSource::new("name", String::new()).into(),
+            src: Arc::new(NamedSource::new("name", String::new())),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,12 @@
+mod args;
+mod ast;
+mod interpreter;
+mod lox;
+mod parser;
+mod resolver;
+mod scanner;
+mod source_span_extensions;
+
 use std::fs;
 
 use clap::Parser;
@@ -9,15 +18,6 @@ use rustyline::{
     error::ReadlineError, highlight::MatchingBracketHighlighter,
     validate::MatchingBracketValidator, Completer, Editor, Helper, Highlighter, Hinter, Validator,
 };
-
-mod args;
-mod ast;
-mod interpreter;
-mod lox;
-mod parser;
-mod resolver;
-mod scanner;
-mod source_span_extensions;
 
 fn main() {
     let args = Args::parse();

--- a/src/parser/expression.rs
+++ b/src/parser/expression.rs
@@ -227,7 +227,7 @@ mod test {
         let expr = parse_expr(tokens).unwrap();
         assert_eq!(
             expr.to_string().trim_end(),
-            r#"(EqualEqual (BangEqual ("foo") ("foo")) ("foo"))"#
+            r#"(== (!= ("foo") ("foo")) ("foo"))"#
         );
     }
 
@@ -239,7 +239,7 @@ mod test {
             token(TokenType::Eof),
         ];
         let expr = parse_expr(tokens).unwrap();
-        assert_eq!(expr.to_string().trim_end(), r#"(Minus (1))"#);
+        assert_eq!(expr.to_string().trim_end(), r#"(- (1))"#);
     }
 
     #[test]
@@ -255,7 +255,7 @@ mod test {
         let expr = parse_expr(tokens).unwrap();
         assert_eq!(
             expr.to_string().trim_end(),
-            "(Logical Or (false) (Logical And (false) (true)))"
+            "(Logical or (false) (Logical and (false) (true)))"
         );
     }
 
@@ -272,7 +272,7 @@ mod test {
         let expr = parse_expr(tokens).unwrap();
         assert_eq!(
             expr.to_string().trim_end(),
-            "(Logical And (Logical And (true) (true)) (false))"
+            "(Logical and (Logical and (true) (true)) (false))"
         );
     }
     #[test]

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -216,7 +216,6 @@ mod test_helpers {
     pub(super) fn token(token_type: TokenType) -> Token {
         Token {
             token_type,
-            lexeme: "FAKE_LEXEME".into(),
             location: (1, 1).into(),
             src: NamedSource::new("", String::new()).into(),
         }
@@ -224,7 +223,6 @@ mod test_helpers {
     pub(super) fn token_with_location(token_type: TokenType, location: SourceSpan) -> Token {
         Token {
             token_type,
-            lexeme: "FAKE_LEXEME".into(),
             location,
             src: NamedSource::new("", String::new()).into(),
         }

--- a/src/parser/statement.rs
+++ b/src/parser/statement.rs
@@ -427,7 +427,7 @@ mod test {
         let stmt = parse_stmt(tokens).unwrap();
         assert_eq!(
             stmt.to_string().trim_end(),
-            "{\nVar name = (nil)\nwhile (EqualEqual (variable name) (nil)) {\n{\nExpr(nil)\nExpr(name=(true))\n}\n}\n}"
+            "{\nVar name = (nil)\nwhile (== (variable name) (nil)) {\n{\nExpr(nil)\nExpr(name=(true))\n}\n}\n}"
         )
     }
 }

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -70,7 +70,6 @@ impl Scanner {
         }
         self.tokens.push(Token::new(
             TokenType::Eof,
-            String::new(),
             (self.current, 0).into(),
             self.named_source.clone(),
         ));
@@ -125,10 +124,8 @@ impl Scanner {
     }
 
     fn add_token(&mut self, token_type: TokenType) {
-        let text = self.source[self.start..self.current].to_string();
         self.tokens.push(Token::new(
             token_type,
-            text,
             (self.start, self.current - self.start).into(),
             self.named_source.clone(),
         ))

--- a/tests/runtime_errors/one_minus_nil.lox
+++ b/tests/runtime_errors/one_minus_nil.lox
@@ -22,7 +22,7 @@ error
       }
     }
   ],
-  "message": "Wrong operand type for operator - : expected Number but got Nil",
+  "message": "Wrong operand type for operator \"-\": expected Number but got Nil",
   "related": [],
   "severity": "error"
 }

--- a/tests/runtime_errors/string_plus_nil.lox
+++ b/tests/runtime_errors/string_plus_nil.lox
@@ -29,7 +29,7 @@ error
       }
     }
   ],
-  "message": "Wrong operand types for operator + : expected both String of both Number but got String and Nil",
+  "message": "Wrong operand types for operator \"+\": expected both String of both Number but got String and Nil",
   "related": [],
   "severity": "error"
 }


### PR DESCRIPTION
reduced memory consumption in ast, less allocations, less complexity
